### PR TITLE
Adjust eyeOpenness calculation to address over-squinting behavior

### DIFF
--- a/TrackingModule.cs
+++ b/TrackingModule.cs
@@ -176,10 +176,10 @@ namespace VirtualDesktop.FaceTracking
 
             eye.Left.Openness = 
                 1.0f - (float)Math.Max(0, Math.Min(1, expressions[(int)Expressions.EyesClosedL]
-                + expressions[(int)Expressions.CheekRaiserL] * expressions[(int)Expressions.LidTightenerL]));
+                + expressions[(int)Expressions.EyesClosedL] * expressions[(int)Expressions.CheekRaiserL] * expressions[(int)Expressions.LidTightenerL]));
             eye.Right.Openness =
                 1.0f - (float)Math.Max(0, Math.Min(1, expressions[(int)Expressions.EyesClosedR]
-                + expressions[(int)Expressions.CheekRaiserR] * expressions[(int)Expressions.LidTightenerR]));
+                + expressions[(int)Expressions.EyesClosedR] * expressions[(int)Expressions.CheekRaiserR] * expressions[(int)Expressions.LidTightenerR]));
 
             #endregion
 


### PR DESCRIPTION
Addresses user complaints about different eyelid behavior between Virtual Desktop module and other Quest Pro modules. 

In last PR from regzo, a change to the eyelid behavior was introduced that made the eyelids close more with squinting. 
This PR changes the calculation to regzo's later suggestion: 
![image](https://github.com/user-attachments/assets/cf7b2ffc-1d64-4f1e-8782-d298f91d75f1)
